### PR TITLE
Fix all games showing up as Jam

### DIFF
--- a/includes/ludumdare.php
+++ b/includes/ludumdare.php
@@ -108,7 +108,7 @@ function ld_fetch_entry($event_id, $uid) {
 			'author' => utf8_decode($author_link->text()),
 			'author_page' => utf8_decode(preg_replace('/..\/author\/(.*)\//i', '$1', $author_link->parent()->attr('href'))),
 			'title' => utf8_decode(pq('#compo2 h2')->eq(0)->text()),
-			'type' => (pq('#compo2 > div > i')->text() == 'Compo Entry') ? 'compo' : 'jam',
+			'type' => (pq('#compo2 > div > i')->text() == 'Competition Entry') ? 'compo' : 'jam',
 			'description' => utf8_decode(pq(pq('#compo2 h2')->eq(1))->prev()->html()),
 			'platforms' => $platforms,
 			'picture' => pq('.shot-nav img')->attr('src'),


### PR DESCRIPTION
Currently all games are showing as Jam. I can't test it on my own machine, but the element that's checked contains Competition Entry for the compo entries, not Compo Entry. This should fix it :)